### PR TITLE
Add a license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,43 @@
+License
+
+  License
+
+    A copyright notice accompanies this license document that identifies
+    the copyright holders.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+    1.  Redistributions in source code must retain the accompanying
+	copyright notice, this list of conditions, and the following
+	disclaimer.
+
+    2.  Redistributions in binary form must reproduce the accompanying
+	copyright notice, this list of conditions, and the following
+	disclaimer in the documentation and/or other materials provided
+	with the distribution.
+
+    3.  Names of the copyright holders must not be used to endorse or
+	promote products derived from this software without prior
+	written permission from the copyright holders.
+
+    4.  If any files are modified, you must cause the modified files to
+	carry prominent notices stating that you changed the files and
+	the date of any change.
+
+    Disclaimer
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND
+      ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+      TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+      PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+      HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+      EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+      TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+      ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+      TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+      THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+      SUCH DAMAGE.
+


### PR DESCRIPTION
This is strongly preferred by downstream distributors like Fedora.

The file is identical to the one at:
    http://repoze.org/LICENSE.txt
