### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
 intersphinx_mapping = {
     'pyramid':
     ('http://docs.pylonsproject.org/projects/pyramid/en/latest/', None),
-    'chameleon': ('https://chameleon.readthedocs.org/en/latest/', None),
+    'chameleon': ('https://chameleon.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -9,5 +9,5 @@ Glossary
    Chameleon
      Chameleon_ is an open-source template engine written in Python_.
 
-.. _Chameleon: https://chameleon.readthedocs.org/en/latest/
+.. _Chameleon: https://chameleon.readthedocs.io/en/latest/
 .. _Python: http://python.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,7 +122,7 @@ implementation that is represented by ``zope.pagetemplates``.
 
 The language definition documentation for Chameleon ZPT-style templates is
 available from the `Chameleon website
-<https://chameleon.readthedocs.org/en/latest/>`_.
+<https://chameleon.readthedocs.io/en/latest/>`_.
 
 Given a :term:`Chameleon` ZPT template named ``foo.pt`` in a directory in your
 application named ``templates``, you can render the template as a
@@ -529,7 +529,7 @@ displaying the arguments passed to the template itself.
    Turning on ``pyramid.debug_templates`` has the same effect as using the
    Chameleon environment variable ``CHAMELEON_DEBUG``.  See `Chameleon
    Configuration
-   <https://chameleon.readthedocs.org/en/latest/configuration.html>`_
+   <https://chameleon.readthedocs.io/en/latest/configuration.html>`_
    for more information.
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
