### PR TITLE
feature request: support --jobs option for precompile command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 0.4 (unreleased)
 ----------------
 
+- Add new command ``pyramid-chameleon-precompile``.
+
 - Remove support for Python 2.6 and 3.2.
 
 - Add support for PyPy3.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,3 +123,5 @@ Jeremy Davis, 2016-02-01
 Steve Piercy, 2016-02-02
 
 Brian Sutherland, 2018-05-22
+
+Hide Hattori, 2018-08-22

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -757,6 +757,24 @@ templates to python. This is executed as follows:
     $ CHAMELEON_CACHE=/path/to/put/precompiled/templates \
         pyramid-chameleon-precompile --dir /path/to/look/for/templates
 
+To further speed up the precompilation, use the ``--jobs <integer>`` option
+with an integer specifying the number of parallel jobs to run on a multiprocessor computer.
+With the ``--jobs`` option, the duration of compilation can be reduced by about one-third
+in projects with over 300 templates, as in this example using ``time``.
+This is executed as follows:
+
+
+.. code-block:: bash
+
+    $ time CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir ~/template_files --jobs 1
+    INFO:root:Compiled 318 out of 318 found templates
+    CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir   1  63.78s user 1.04s system 92% cpu 1:09.71 total
+    $ rm -rf ~/tmp_chameleoncache/*
+    $ time CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir ~/template_files --jobs 2
+    INFO:root:Compiled 318 out of 318 found templates
+    CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir   2  78.24s user 1.07s system 172% cpu 45.959 total
+
+
 More information
 ================
 


### PR DESCRIPTION
Hi,

precompile command is nice feature.
I want to improve the performance when I run precompile command.
Because there are over 300 target files in my use case.

So I added the `--jobs` option.
This option improves performance by running `compile_one` in parallel using `multiprocessing.Pool`.

execution result:
```
$ time CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir ~/template_files --jobs 1
INFO:root:Compiled 318 out of 318 found templates
CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir   1  63.78s user 1.04s system 92% cpu 1:09.71 total
$ rm -rf ~/tmp_chameleoncache/*
$ time CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir ~/template_files --jobs 2
INFO:root:Compiled 318 out of 318 found templates
CHAMELEON_CACHE=~/tmp_chameleoncache pyramid-chameleon-precompile --dir   2  78.24s user 1.07s system 172% cpu 45.959 total
```

Thanks