### PR TITLE
docs: Fix simple typo, renderered -> rendered

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -597,7 +597,7 @@ representing your Pyramid app) or they can be passed directly within the
 
 
 Changing the Content-Type of a Chameleon-rendered response
-------------------------------------------------------------
+----------------------------------------------------------
 
 Here's an example of changing the content-type and status of the
 response object returned by a Chameleon-rendered Pyramid view:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -596,7 +596,7 @@ representing your Pyramid app) or they can be passed directly within the
    have extra debugging info turned on in tracebacks it generates.
 
 
-Changing the Content-Type of a Chameleon-renderered response
+Changing the Content-Type of a Chameleon-rendered response
 ------------------------------------------------------------
 
 Here's an example of changing the content-type and status of the


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Closes #28

