### PR TITLE
compatibility with pyramid 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
@@ -20,12 +18,8 @@ matrix:
       env: TOXENV=py38
       dist: xenial
       sudo: true
-    - python: pypy
-      env: TOXENV=pypy
     - python: pypy3
       env: TOXENV=pypy3
-    - python: 3.5
-      env: TOXENV=py2-cover,py3-cover,coverage
     - python: 3.5
       env: TOXENV=docs
   allow_failures:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -125,3 +125,5 @@ Steve Piercy, 2016-02-02
 Brian Sutherland, 2018-05-22
 
 Hide Hattori, 2018-08-22
+
+Markéta Machová, 2021-08-03

--- a/pyramid_chameleon/tests/test_text.py
+++ b/pyramid_chameleon/tests/test_text.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 
-from pyramid.compat import binary_type
 from pyramid import testing
 
 class Base(object):
@@ -97,7 +96,7 @@ class TextTemplateRendererTests(Base, unittest.TestCase):
         lookup = DummyLookup()
         instance = self._makeOne(minimal, lookup)
         result = instance({}, {})
-        self.assertTrue(isinstance(result, binary_type))
+        self.assertTrue(isinstance(result, bytes))
         self.assertEqual(result, b'Hello.\n')
 
     def test_call_with_nondict_value(self):
@@ -111,7 +110,7 @@ class TextTemplateRendererTests(Base, unittest.TestCase):
         lookup = DummyLookup()
         instance = self._makeOne(nonminimal, lookup)
         result = instance({'name':'Chris'}, {})
-        self.assertTrue(isinstance(result, binary_type))
+        self.assertTrue(isinstance(result, bytes))
         self.assertEqual(result, b'Hello, Chris!\n')
 
     def test_implementation(self):
@@ -119,7 +118,7 @@ class TextTemplateRendererTests(Base, unittest.TestCase):
         lookup = DummyLookup()
         instance = self._makeOne(minimal, lookup)
         result = instance.implementation()()
-        self.assertTrue(isinstance(result, binary_type))
+        self.assertTrue(isinstance(result, bytes))
         self.assertEqual(result, b'Hello.\n')
 
 class DummyLookup(object):

--- a/pyramid_chameleon/tests/test_zpt.py
+++ b/pyramid_chameleon/tests/test_zpt.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 
 from pyramid import testing
-from pyramid.compat import text_type
 
 class Base(object):
     def setUp(self):
@@ -54,7 +53,7 @@ class ZPTTemplateRendererTests(Base, unittest.TestCase):
         lookup = DummyLookup()
         instance = self._makeOne(minimal, lookup)
         result = instance({}, {})
-        self.assertTrue(isinstance(result, text_type))
+        self.assertTrue(isinstance(result, str))
         self.assertEqual(result.rstrip('\n'),
                      '<div xmlns="http://www.w3.org/1999/xhtml">\n</div>')
 
@@ -121,7 +120,7 @@ class ZPTTemplateRendererTests(Base, unittest.TestCase):
         lookup = DummyLookup()
         instance = self._makeOne(minimal, lookup)
         result = instance.implementation()()
-        self.assertTrue(isinstance(result, text_type))
+        self.assertTrue(isinstance(result, str))
         self.assertEqual(result.rstrip('\n'),
                      '<div xmlns="http://www.w3.org/1999/xhtml">\n</div>')
 

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(name='pyramid_chameleon',
       classifiers=[
         "Programming Language :: Python",
         "Framework :: Pylons",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,19 @@
 [tox]
 envlist = 
-    py27,pypy,py34,py35,py36,py37,py38,pypy3,
+    pypy,py34,py35,py36,py37,py38,pypy3,
     docs,
-    {py2,py3}-cover,coverage
+    py3-cover,coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
 # to defaults for others.
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
     pypy: pypy
-    py2: python2.7
     py3: python3.5
 commands =
     pip install pyramid_chameleon[testing]


### PR DESCRIPTION
pyramid.compat was dropped in pyramid 2. As per https://github.com/Pylons/pyramid/commit/b1a257bacc1c4ac2c1401ed02c51d9c6c03685d2 this should be equivalent.