### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -502,7 +502,7 @@ from rendering a template with an undefined variable
   NameError: wrong
 
 Note that the exception has no information about which template was
-being rendered when the error occured.  But with template debugging
+being rendered when the error occurred.  But with template debugging
 on, an exception resulting from the same problem might end like so:
 
 .. code-block:: text


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md